### PR TITLE
Fix out of bounds index on table.insert

### DIFF
--- a/SeaBlock/lib.lua
+++ b/SeaBlock/lib.lua
@@ -38,7 +38,7 @@ lib.moveeffect = function(name, fromtech, totech, insertindex)
     log('Effect ' .. name .. ' not found in tech ' .. fromtech)
     return
   end
-  if insertindex then
+  if insertindex and insertindex <= #data.raw.technology[totech].effects then
     table.insert(data.raw.technology[totech].effects, insertindex, effect)
   else
     table.insert(data.raw.technology[totech].effects, effect)
@@ -57,7 +57,7 @@ local function add_recipe_unlock(technology, recipe, insertindex)
   end
   if addit then
     bobmods.lib.recipe.enabled(recipe, false)
-    if insertindex then
+    if insertindex and insertindex <= #technology.effects then
       table.insert(technology.effects, insertindex, {type = "unlock-recipe", recipe = recipe})
     else
       table.insert(technology.effects, {type = "unlock-recipe", recipe = recipe})


### PR DESCRIPTION
# Summary
Factorio silently accepts an out-of-bounds insertion index in table.insert, but [YAFC](https://github.com/ShadowTheAge/yafc), in particular, does not, causing a crash.

# Steps to Reproduce
I unpacked a fresh Factorio 1.1.19 and installed SeaBlock 0.5.2 (which pulls in angelsbioprocessing_0.7.17, angelspetrochem_0.9.17, angelsrefining, angelsrefining_0.11.19, angelssmelting_0.6.14, A Sea Block Config_0.5.1, bobelectronics_1.1.3, boblibrary_1.1.2, boblogistics_1.1.2, bobplates_1.1.2). Then I installed the upstream version of YAFC (commit 72dd2810, version 0.5.4.1) and pointed it towards the aforementioned Factorio install:

```
Unhandled exception. YAFC.Parser.LuaException: (SeaBlock, lib.lua):42: bad argument #2 to 'insert' (position out of bounds)
stack traceback:
[C]: in ?
[C]: in function 'insert'
(SeaBlock, lib.lua):42: in function 'moveeffect'
(SeaBlock, data-updates/startup.lua):301: in main chunk
[C]: in function 'require'
(SeaBlock, data-updates.lua):14: in main chunk
```

# Details

The lines in the above stacktrace try to perform a `table.insert` with an out-of-bounds insertion index. Factorio accepts this silently, creating a malformed list (i.e. `table.insert({1, 1}, 2, 30)` results in `{1, 1, [30] = 2}`), but the lua runtime used by YAFC complains.

Of course, out-of-bounds inserts ideally should not happen at all, then this would not be a problem, but for the moment the attached commit should make the behaviour consistent and less brittle.