### PR TITLE
Added exception for Deep Oil

### DIFF
--- a/SeaBlock/data-updates/misc.lua
+++ b/SeaBlock/data-updates/misc.lua
@@ -72,7 +72,7 @@ end
 
 -- Remove resources so mining recipes don't show in FNEI
 for k,v in pairs(data.raw['resource']) do
-  if k ~='iron-ore' and k ~= 'coal' then
+  if k ~='iron-ore' and k ~= 'coal' and k~= "deep_oil" then
     data.raw['resource'][k] = nil
   end
 end


### PR DESCRIPTION
This allows Deep Oil from Cargo Ships Mod to exist. This mostly fixes error in Issue #124 but does not make it so the oil doesn't spawn and is thus somewhat broken.