### PR TITLE
fix #268

### DIFF
--- a/SeaBlock/changelog.txt
+++ b/SeaBlock/changelog.txt
@@ -2,6 +2,7 @@ Version: 0.5.12
 Date: ???
   Bugfixes:
     - Basic Chemistry 2 tech missing green science #269
+    - Fix multiple startitems in rock-chest and playerinventory #268
 ---------------------------------------------------------------------------------------------------
 Version: 0.5.11
 Date: 06.06.2022

--- a/SeaBlock/control.lua
+++ b/SeaBlock/control.lua
@@ -9,7 +9,7 @@ function seablock.give_research(force)
   end
 end
 
-function seablock.init_singleplayer(surface, pos)
+function seablock.create_rock_chest(surface, pos)
   local has_items = false
 
   if global.starting_items and (not game.is_multiplayer()) then
@@ -26,16 +26,6 @@ function seablock.init_singleplayer(surface, pos)
     for item,quantity in pairs(global.starting_items) do
       if quantity > 0 then
         chest.insert{name = item, count = quantity}
-      end
-    end
-  end
-
-  -- remove startup items from player in singleplayer.
-  if not game.is_multiplayer() then
-    local inv = game.players[1].get_main_inventory()
-    for item,quantity in pairs(global.starting_items) do
-      if quantity > 0 then
-        inv.remove{name = item, count = quantity}
       end
     end
   end
@@ -86,13 +76,6 @@ local function init()
     created_items['stone-furnace'] = nil
     created_items['iron-plate'] = nil
     created_items['wood'] = nil
-    -- game.is_multiplayer() is not working in on_init, always give items to player and remove in singleplayer.
-    for item, quantity in pairs(global.starting_items) do
-      if quantity > 0 then
-        created_items[item] = quantity
-      end
-    end
-
     remote.call("freeplay", "set_created_items", created_items)
   end
 end
@@ -121,7 +104,7 @@ script.on_event(defines.events.on_chunk_generated,
     local rby = e.area.right_bottom.y
     for _,pos in pairs(surface.map_gen_settings.starting_points) do
       if pos.x >= ltx and pos.y >= lty and pos.x < rbx and pos.y < rby then
-        seablock.init_singleplayer(surface, pos)
+        seablock.create_rock_chest(surface, pos)
       end
     end
   end
@@ -199,6 +182,19 @@ script.on_configuration_changed(
 script.on_load(
   function()
     set_pvp()
+  end
+)
+
+script.on_event(defines.events.on_player_created,
+  function (e)
+    if game.is_multiplayer() then
+      local inv = game.players[e.player_index].get_main_inventory()
+      for item,quantity in pairs(global.starting_items) do
+        if quantity > 0 then
+          inv.insert{name = item, count = quantity}
+        end
+      end
+    end
   end
 )
 

--- a/SeaBlock/control.lua
+++ b/SeaBlock/control.lua
@@ -187,7 +187,7 @@ script.on_load(
 
 script.on_event(defines.events.on_player_created,
   function (e)
-    if game.is_multiplayer() then
+    if global.starting_items and game.is_multiplayer() then
       local inv = game.players[e.player_index].get_main_inventory()
       for item,quantity in pairs(global.starting_items) do
         if quantity > 0 then

--- a/SeaBlock/control.lua
+++ b/SeaBlock/control.lua
@@ -9,7 +9,7 @@ function seablock.give_research(force)
   end
 end
 
-function seablock.give_items(surface, pos)
+function seablock.init_singleplayer(surface, pos)
   local has_items = false
 
   if global.starting_items and (not game.is_multiplayer()) then
@@ -23,10 +23,19 @@ function seablock.give_items(surface, pos)
 
   if has_items then
     local chest = surface.create_entity({name = "rock-chest", position = pos, force = game.forces.neutral})
-    
     for item,quantity in pairs(global.starting_items) do
       if quantity > 0 then
         chest.insert{name = item, count = quantity}
+      end
+    end
+  end
+
+  -- remove startup items from player in singleplayer.
+  if not game.is_multiplayer() then
+    local inv = game.players[1].get_main_inventory()
+    for item,quantity in pairs(global.starting_items) do
+      if quantity > 0 then
+        inv.remove{name = item, count = quantity}
       end
     end
   end
@@ -77,12 +86,10 @@ local function init()
     created_items['stone-furnace'] = nil
     created_items['iron-plate'] = nil
     created_items['wood'] = nil
-    
-    if not game.is_multiplayer() then
-      for item, quantity in pairs(global.starting_items) do
-        if quantity > 0 then
-          created_items[item] = quantity
-        end
+    -- game.is_multiplayer() is not working in on_init, always give items to player and remove in singleplayer.
+    for item, quantity in pairs(global.starting_items) do
+      if quantity > 0 then
+        created_items[item] = quantity
       end
     end
 
@@ -114,7 +121,7 @@ script.on_event(defines.events.on_chunk_generated,
     local rby = e.area.right_bottom.y
     for _,pos in pairs(surface.map_gen_settings.starting_points) do
       if pos.x >= ltx and pos.y >= lty and pos.x < rbx and pos.y < rby then
-        seablock.give_items(surface, pos)
+        seablock.init_singleplayer(surface, pos)
       end
     end
   end


### PR DESCRIPTION
game.is_multiplayer() is not working in on_init event.
- always give playeres starting items
- remove items in singleplayer from player when rock-chest is created
- rename function